### PR TITLE
Fix engine bugs (rook check, en passant) + regression tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ chess-engine = "chess_ai.engine.app:main"   # from-scratch engine (pygame only)
 chess-gui = "chess_ai.gui.game:main"         # Maia AI GUI (requires the "ml" extra)
 
 [dependency-groups]
-dev = ["black>=24.4"]
+dev = ["black>=24.4", "pytest>=8"]
 
 [tool.uv]
 # TensorFlow 2.15 ships no aarch64-Linux wheel for this pin, so resolve the

--- a/src/chess_ai/engine/app.py
+++ b/src/chess_ai/engine/app.py
@@ -241,7 +241,7 @@ class Chess:
         ):  # if en passant
             self.board[from_row][to_col] = "."
         if fig.lower() == "p" and abs(from_row - to_row) == 2:
-            self.en_passant_target = (from_col, from_row + to_row / 2)
+            self.en_passant_target = (from_col, (from_row + to_row) // 2)
         self.board[to_row][to_col] = fig
         self.board[from_row][from_col] = "."
 
@@ -680,7 +680,7 @@ class Chess:
                     target_piece = board[new_row][new_col]
                     if target_piece != ".":
                         if (
-                            target_piece.lower() == "q"
+                            target_piece.lower() in ("r", "q")
                             and target_piece.islower() != fig.islower()
                         ):
                             return True

--- a/src/chess_ai/gui/game.py
+++ b/src/chess_ai/gui/game.py
@@ -30,7 +30,7 @@ WHITE = (255, 255, 255)
 BLACK = (0, 0, 0)
 LIGHT_SQUARE = (240, 217, 181)
 DARK_SQUARE = (181, 136, 99)
-BACKGROUND = (73, 57, 44)
+BG_COLOR = (73, 57, 44)
 
 WHITE_IS_HUMAN = True
 BLACK_IS_HUMAN = False
@@ -506,7 +506,7 @@ def start_game(mode, color):
         # Options handling can be added here
         pass
     screen = pygame.display.set_mode((TOTAL_WIDTH, TOTAL_HEIGHT))
-    screen.fill(BACKGROUND)
+    screen.fill(BG_COLOR)
     pygame.display.set_caption("Chess")
     clock = pygame.time.Clock()
     images, small_images = load_images()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,42 @@
+"""Regression tests for the from-scratch chess engine (`chess_ai.engine.app`).
+
+These pin down two bugs that previously slipped through silently:
+
+* the rook branch of ``is_king_attacked`` only matched queens, so checks
+  delivered by a rook along a rank/file went undetected;
+* a pawn's double step computed the en-passant target row as
+  ``from_row + to_row / 2`` (a float, and the wrong square) instead of the
+  integer midpoint.
+"""
+
+from chess_ai.engine.app import Chess
+
+
+def _empty_board() -> list[list[str]]:
+    return [["." for _ in range(8)] for _ in range(8)]
+
+
+def test_rook_gives_check() -> None:
+    game = Chess()
+    board = _empty_board()
+    board[4][4] = "K"  # our (white) king
+    board[4][0] = "r"  # enemy rook on the same rank, clear path between
+    assert game.is_king_attacked(board, "K") is True
+
+
+def test_blocked_rook_does_not_give_check() -> None:
+    game = Chess()
+    board = _empty_board()
+    board[4][4] = "K"
+    board[4][0] = "r"
+    board[4][2] = "P"  # our own pawn blocks the rook's line
+    assert game.is_king_attacked(board, "K") is False
+
+
+def test_en_passant_target_is_integer_midpoint() -> None:
+    game = Chess()
+    game.board = _empty_board()
+    game.board[6][3] = "P"
+    game.move((6, 3, 4, 3))  # white pawn double step
+    assert game.en_passant_target == (3, 5)
+    assert isinstance(game.en_passant_target[1], int)

--- a/uv.lock
+++ b/uv.lock
@@ -163,6 +163,7 @@ ml = [
 [package.dev-dependencies]
 dev = [
     { name = "black", marker = "(platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "pytest", marker = "(platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -177,7 +178,10 @@ requires-dist = [
 provides-extras = ["ml"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "black", specifier = ">=24.4" }]
+dev = [
+    { name = "black", specifier = ">=24.4" },
+    { name = "pytest", specifier = ">=8" },
+]
 
 [[package]]
 name = "click"
@@ -233,6 +237,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
     { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
     { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -340,6 +356,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -497,6 +522,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "4.25.9"
 source = { registry = "https://pypi.org/simple" }
@@ -553,6 +587,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/a1/9ae2852ebd3a7cc7d9ae7ff7919ab983e4a5c1b7a14e840732f23b2b48f6/pygame-2.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce8cc108b92de9b149b344ad2e25eedbe773af0dc41dfb24d1f07f679b558c60", size = 13977107, upload-time = "2024-09-29T11:39:56.831Z" },
     { url = "https://files.pythonhosted.org/packages/31/df/6788fd2e9a864d0496a77670e44a7c012184b7a5382866ab0e60c55c0f28/pygame-2.6.1-cp311-cp311-win32.whl", hash = "sha256:811e7b925146d8149d79193652cbb83e0eca0aae66476b1cb310f0f4226b8b5c", size = 10250863, upload-time = "2024-09-29T11:44:48.199Z" },
     { url = "https://files.pythonhosted.org/packages/d2/55/ca3eb851aeef4f6f2e98a360c201f0d00bd1ba2eb98e2c7850d80aabc526/pygame-2.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:91476902426facd4bb0dad4dc3b2573bc82c95c71b135e0daaea072ed528d299", size = 10622016, upload-time = "2024-09-29T12:17:01.545Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "(python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "iniconfig", marker = "(platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "pluggy", marker = "(platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "pygments", marker = "(platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cleans up three correctness bugs in the from-scratch engine and adds regression tests.

## Bugs fixed
- **Rook checks were undetected.** In `Chess.is_king_attacked`, the orthogonal-sliding branch matched only `"q"`, so a rook giving check along a rank/file was ignored (`engine/app.py`). Now matches `("r", "q")`.
- **Broken en-passant target.** A pawn double step computed the target row as `from_row + to_row / 2` — a float, and the wrong square. Now the integer midpoint `(from_row + to_row) // 2` (`engine/app.py`).
- **`BACKGROUND` name collision.** In the GUI, a colour tuple `BACKGROUND = (73, 57, 44)` shadowed the imported `BACKGROUND` image **path**, so `load_background()` called `pygame.image.load(str(<colour tuple>))`. The colour constant is renamed to `BG_COLOR` (`gui/game.py`).

## Tests
- `tests/test_engine.py` — 3 regression tests (rook check, blocked rook, en-passant midpoint). All pass locally (`uv run pytest`), `black --check` clean.

> Note: a GitHub Actions CI workflow (black + pytest on 3.10/3.11) is ready but not in this push — the active token lacks the `workflow` scope. Will add it once scope is granted.